### PR TITLE
fix: Missing parahraph in the hive-trusted-api-endpoint article

### DIFF
--- a/hive-trusted-api-endpoint/README.md
+++ b/hive-trusted-api-endpoint/README.md
@@ -269,12 +269,12 @@ oc describe ClusterDeployment "${managed_cluster_name}" \
     --namespace "${managed_cluster_name}"
 ```
 
-The command 
+The command output should contain the following excerpt arount the `Unreachable` condition:
 
 ```txt
     ...
-    Last Probe Time:          2022-12-06T15:27:31Z
-    Last Transition Time:     2022-12-06T15:27:31Z
+    Last Probe Time:          ...
+    Last Transition Time:     ...
     Message:                  cluster is reachable
     Reason:                   ClusterReachable
     Status:                   False


### PR DESCRIPTION
Signed-off-by: Denilson Nastacio <dnastacio@gmail.com>
